### PR TITLE
docs: clarify first reboot should not hold Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,26 +403,68 @@ printf '%s' "$DEV" | sudo tee /sys/bus/hid/drivers/apple-ibridge-hid/bind >/dev/
 
 ### Install
 
+`drivers/appleibridge/` is **patched kernel source**, not a script you run. Do this
+from inside Omarchy. The bugs above are already fixed in those files; the service
+is what actually lights the strip.
+
+**0. Confirm the T1 is alive.** You want `05ac:8600`. If you see `1281`, stop —
+firmware is gone and no driver will help.
+
 ```bash
-sudo pacman -S --needed linux-headers dkms
+for d in /sys/bus/usb/devices/*/; do
+  [ "$(cat "$d/idVendor" 2>/dev/null)" = "05ac" ] &&
+    echo "05ac:$(cat "$d/idProduct" 2>/dev/null) $(cat "$d/product" 2>/dev/null)"
+done
+```
+
+Remove Omarchy's broken SPI DKMS package if it is present. It collides with this
+driver:
+
+```bash
+sudo dkms remove -m macbook12-spi-driver -v 0+git.315 --all
+sudo pacman -R macbook12-spi-driver-dkms
+modinfo -n applespi   # confirm mainline still provides it
+```
+
+**1. Get this repo onto the machine.**
+
+```bash
+sudo pacman -S --needed git base-devel linux-headers dkms zstd
+git clone https://github.com/nohzafk/omarchy-macbookpro-t1.git
+cd omarchy-macbookpro-t1
+```
+
+A USB copy of the tree works the same way. The `sudo cp` below is relative to the
+repo root.
+
+**2. Build the modules with DKMS.**
+
+```bash
 sudo mkdir -p /usr/src/appleibridge-0.1
 sudo cp drivers/appleibridge/{*.c,*.h,Makefile,dkms.conf} /usr/src/appleibridge-0.1/
 sudo dkms add -m appleibridge -v 0.1
 sudo dkms build -m appleibridge -v 0.1
 sudo dkms install -m appleibridge -v 0.1
-
-sudo install -m 755 systemd/touchbar-enable.sh /usr/local/sbin/
-sudo install -m 644 systemd/touchbar.service   /etc/systemd/system/
-sudo systemctl daemon-reload && sudo systemctl enable --now touchbar.service
-journalctl -u touchbar.service -n 20
 ```
 
-Expect `SUCCESS: fnmode=0 idle=-1 dim=-1`.
+**3. Install the service that takes interface `.0002` back.** Building is not
+enough. At boot `hid-sensor-hub` steals the Touch Bar reports; the modules load,
+`dmesg` looks fine, and the strip stays dark. The service fixes that.
 
-The service runs **after `multi-user.target`** on purpose. Loading these modules from
-`/etc/modules-load.d/` hangs `sysinit.target` when anything wedges, and the only recovery is a
-forced power-off — that cost three power-offs while working this out. Late means a failure
-costs a dark strip and nothing else. The strip appears a few seconds after login.
+```bash
+sudo install -m 755 systemd/touchbar-enable.sh /usr/local/sbin/touchbar-enable.sh
+sudo install -m 644 systemd/touchbar.service   /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl enable --now touchbar.service
+journalctl -u touchbar.service -n 20 --no-pager
+```
+
+Expect `SUCCESS: fnmode=0 idle=-1 dim=-1` and both interfaces owned by
+`apple-ibridge-hid`. The strip appears a few seconds after login, Esc + F1–F12.
+
+Do **not** put these modules in `/etc/modules-load.d/`. If they wedge at boot they
+hang `sysinit.target` and the only recovery is a forced power-off. The service
+runs after `multi-user.target` on purpose: a failure then costs a dark strip,
+not an unbootable machine.
 
 ### Things that look like failure but are not
 

--- a/README.md
+++ b/README.md
@@ -479,41 +479,114 @@ not an unbootable machine.
 
 ---
 
-## Part 7 — No Touch Bar means no keys, and that has a config answer
+## Part 7 — Missing Esc and F-keys, without the Touch Bar
 
-Worth stating plainly, because it is the lesson that took longest to learn: **on a Touch Bar
-Mac, Esc and F1–F12 are virtual keys that only exist when the Touch Bar driver works.** Seven
-things break as a result, and every one has a config-level fix needing no driver at all:
+If Part 6 already lit the strip, skip this. Esc and F1–F12 exist on the Touch Bar,
+and Omarchy's volume/brightness bindings (`XF86*`) work.
 
-| Lost | Fix |
-| --- | --- |
-| **Escape** | Map Caps Lock. In Omarchy 4.x, `~/.config/hypr/input.lua`:<br>`hl.config({ input = { kb_options = "caps:escape" } })` |
-| Volume, brightness, keyboard light, mute, mic mute | Omarchy binds these to `XF86*` keycodes the Touch Bar emits. Rebind to `SUPER+CTRL+arrows`, which Omarchy leaves free apart from LEFT/RIGHT |
-| Dictation push-to-talk (`F9`) | Use the toggle, `SUPER + CTRL + X` |
-| `Ctrl+Alt+F2` for a TTY | Unavailable. Keep a USB keyboard for recovery |
+If the strip is still dark, those keys **do not exist on the keyboard**. Caps Lock
+is the only nearby key you can turn into Escape. Volume, brightness, mute and
+keyboard light have no hardware keys at all until you bind them to something else.
 
-Omarchy 4.x configures Hyprland in **Lua**, not `.conf`, and ships `input.lua` as an
-all-commented template.
+Omarchy 4.x / Quattro uses Lua. The user file is `~/.config/hypr/input.lua` (also
+reachable via Super+Space → Setup → Input). It ships as an all-commented template.
+Omarchy's default already sets `kb_options = "compose:caps,..."` — Caps Lock is
+the compose key — so you **replace** that option, you do not add a second line.
 
-If your goal is simply "I need an Escape key", stop here — that is three lines and thirty
-seconds. The Touch Bar is a separate, optional project.
+**Escape from Caps Lock:**
+
+```lua
+-- ~/.config/hypr/input.lua
+hl.config({
+  input = {
+    kb_options = "caps:escape",
+  },
+})
+```
+
+Then `hyprctl reload`. Tap Caps Lock; it should send Escape (exit insert mode in
+vim, close menus). You lose Caps Lock itself and Omarchy's compose-on-Caps
+shortcut. Move compose to Right Alt if you still want it:
+
+```lua
+hl.config({
+  input = {
+    kb_options = "caps:escape,compose:ralt",
+  },
+})
+```
+
+**Volume and brightness without F-keys.** Omarchy binds those to `XF86*` keycodes
+the Touch Bar emits. With a dark strip they never fire. Add fallbacks in
+`~/.config/hypr/bindings.lua`. Super+Ctrl+Up/Down/Left are free; Super+Ctrl+L
+is already Lock, so do not use Left for anything you will hit by accident.
+
+```lua
+-- ~/.config/hypr/bindings.lua
+o.bind("SUPER + CTRL + UP",    "Volume up",   "omarchy-swayosd-client --output-volume raise", { repeating = true })
+o.bind("SUPER + CTRL + DOWN",  "Volume down", "omarchy-swayosd-client --output-volume lower", { repeating = true })
+o.bind("SUPER + CTRL + RIGHT", "Brightness up",   "omarchy-brightness-display +5%", { repeating = true })
+o.bind("SUPER + SHIFT + DOWN", "Brightness down", "omarchy-brightness-display 5%-", { repeating = true })
+```
+
+`hyprctl reload` again. Dictation, if you use it, is already `SUPER + CTRL + X`
+and does not need F9.
+
+**A TTY (`Ctrl+Alt+F2`) is unavailable** on a Touch Bar machine with a dark
+strip. Keep a USB keyboard for recovery.
 
 ---
 
-## Part 8 — Suspend, fans, USB-C
+## Part 8 — Suspend, USB-C, fans
 
-**Suspend works.** Omarchy's `d3cold_allowed=0` fix is applied automatically. Two things that
-read as failure:
+### Suspend
 
-- Resume takes ~15 s **and needs a keypress** — opening the lid alone does not finish the
-  wake. Wait a full minute before concluding it is hung.
-- Two Thunderbolt xHCI controllers fail to reset (`Host halt failed, -19`), leaving USB-C dead
-  until reboot. Fixed with `pcie_ports=compat` — afterwards all three controllers bind.
+Omarchy already applies the NVMe fix (`d3cold_allowed=0`). You do not install
+anything else.
 
-**Fans need nothing.** `applesmc` loads itself and reports both fans plus ~40 SMC sensors.
-`fan*_manual = 0` means the SMC controls them in firmware: observed 2101 → 3660 RPM under
-load with temperature falling 68 → 61 °C. Guides recommending `mbpfan` for these machines are
-wrong — it only lets you reshape a curve that already works.
+Suspend from the session: **Super+Escape** → Suspend. Closing the lid also works
+once logind is set to suspend on lid close.
+
+Resume looks hung if you only open the lid. Wait ~15 seconds **and press a
+key**. Opening the lid alone does not finish the wake. Give it a full minute
+before a forced power-off.
+
+### USB-C after resume
+
+Without `pcie_ports=compat`, two Thunderbolt xHCI controllers fail to reset
+(`Host halt failed, -19`) and USB-C stays dead until reboot. That parameter
+belongs in a limine **drop-in**, not in `/boot/limine.conf` — that file is
+regenerated. If you skipped it in Part 2:
+
+```bash
+sudo tee /etc/limine-entry-tool.d/macbook-t1.conf <<'EOF'
+KERNEL_CMDLINE[default]+=" pcie_ports=compat"
+EOF
+sudo limine-update
+sudo reboot
+```
+
+Confirm it is on the running kernel, then that three xHCI controllers bound:
+
+```bash
+cat /proc/cmdline | tr ' ' '\n' | grep pcie_ports
+dmesg | grep -i xhci
+```
+
+Plug something into USB-C after a resume. If it enumerates, the parameter took.
+
+### Fans
+
+Do **not** install `mbpfan`. `applesmc` loads itself and the SMC already runs
+both fans in firmware (`fan*_manual = 0`). On this machine they moved 2101 →
+3660 RPM under load while temperature fell 68 → 61 °C. `mbpfan` only lets you
+reshape a curve that already works.
+
+```bash
+lsmod | grep applesmc
+# optional, if lm_sensors is installed:
+sensors
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,11 @@ nvme0n1p4  129G   crypto_LUKS   <- Omarchy root
 
 It boots as the firmware default, but holding Option shows only "Macintosh HD". Apple's
 picker lists a generic "EFI Boot" entry only when it finds `\EFI\BOOT\BOOTX64.EFI`, and
-Omarchy never creates it — it registers an NVRAM variable instead. Fix it permanently, from
-Omarchy:
+Omarchy never creates it — it registers an NVRAM variable instead.
+
+**Do not hold Option on the first reboot.** A normal power-on follows that NVRAM variable
+and lands in Omarchy. Holding Option is what hides it, which makes the next step look
+impossible. Once you are in, fix the picker permanently:
 
 ```bash
 sudo mkdir -p /boot/EFI/BOOT


### PR DESCRIPTION
**First reboot / Option picker.** Holding Option only shows Macintosh HD, so it is easy to conclude you cannot reach Omarchy to copy BOOTX64.EFI. Added two sentences: do not hold Option; a normal power-on follows the NVRAM variable.

**Touch Bar install.** `drivers/appleibridge/` looks like something you run. Part 6 jumped into a `sudo cp` that assumes the repo is already on disk. The Install section now spells out: confirm 05ac:8600, remove the colliding SPI DKMS package, clone this repo, DKMS build, install touchbar.service.

Verified on a 2017 MacBook Pro (T1): Option hid Omarchy, a normal reboot did not. Touch Bar works now too. 